### PR TITLE
fixed parsing of disconnect response

### DIFF
--- a/lib/bglib-responses.js
+++ b/lib/bglib-responses.js
@@ -118,7 +118,7 @@ var _bgResponseAttributesUserWriteResponse = function(params) {
 ****************************************/
 var _bgResponseConnectionDisconnect = function(params) {
 	this.connection = params.readUInt8(0);
-	this.result = errorHandler.getErrorFromCode(params.readUInt16LE(0));
+	this.result = errorHandler.getErrorFromCode(params.readUInt16LE(1));
 }
 var _bgResponseConnectionGetRSSI = function(params) {
 	this.connection = params.readUInt8(0);


### PR DESCRIPTION
error code starts at byte 1, not at byte 0